### PR TITLE
change short_query to raknet_ping as well as change over model data!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,3 @@ tokio = {version='1.10.0', features = ['full']}
 hex = "0.4.3"
 byteorder = "1.4.3"
 rand = "0.8.4"
-actix-rt = "2.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use tokio::net::{UdpSocket, ToSocketAddrs};
 use std::io::{Result, ErrorKind, Error, Write};
 use hex::FromHex;
-use crate::model::{ShortQuery, LongQuery, packet};
+use crate::model::{ShortQuery, LongQuery, packet, RakNetPong};
 use std::time::{SystemTime, UNIX_EPOCH};
 use byteorder::{WriteBytesExt, BigEndian};
 use rand::Rng;
@@ -111,7 +111,7 @@ impl<A: ToSocketAddrs> Client<A> {
     /// // Prints out the amount of players on that server at the time of querying.
     /// println!("player_count: {}", data.player_count); // EX: player_count: 5
     /// ```
-    pub async fn short_query(&self) -> Result<ShortQuery> {
+    pub async fn raknet_ping(&self) -> Result<RakNetPong> {
         // Writing
         let mut random = rand::thread_rng();
         let offline_msg_data = Vec::from_hex("00ffff00fefefefefdfdfdfd12345678").expect("Failed to read binary string!");
@@ -140,7 +140,7 @@ impl<A: ToSocketAddrs> Client<A> {
             motd.push(data[7].clone());
             gamemode = Some(data[8].clone())
         }
-        Ok(ShortQuery {
+        Ok(RakNetPong {
             game_edition: data[0].clone(),
             motd,
             protocol_version: data[2].parse().unwrap(),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,6 +1,8 @@
 mod long_query;
 mod short_query;
 pub mod packet;
+mod raknet_pong;
 
 pub use long_query::LongQuery;
 pub use short_query::ShortQuery;
+pub use raknet_pong::RakNetPong;

--- a/src/model/raknet_pong.rs
+++ b/src/model/raknet_pong.rs
@@ -1,0 +1,22 @@
+#[allow(dead_code)]
+/// RakNetPong is a model of data returned by raknet Unconnected Ping
+///
+/// This data includes game_edition to server_unique_id in most implementations.
+///
+/// Depending on the server software gamemode_mode and port information might not be included
+/// which is a Option is wrapped around its type.
+///
+#[derive(Debug)]
+pub struct RakNetPong {
+    pub game_edition:      String,
+    pub motd:              Vec<String>,
+    pub protocol_version:  usize,
+    pub game_version:      String,
+    pub player_count:      usize,
+    pub max_player_count:  usize,
+    pub server_uid:        String,
+    pub game_mode:         Option<String>,
+    pub game_mode_integer: Option<usize>,
+    pub port:              Option<u16>,
+    pub port_v6:           Option<u16>
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,16 +3,16 @@ use std::io::Result;
 use tokio::time::Instant;
 use tokio::io::AsyncWriteExt;
 
-#[actix_rt::test]
-async fn short_query() -> Result<()> {
+#[tokio::test]
+async fn raknet_ping() -> Result<()> {
     let client = Client::new("velvetpractice.live:19132").await?;
     let start = Instant::now();
-    let data = client.short_query().await?;
+    let data = client.raknet_ping().await?;
     println!("short finished in {}ms\n{:?}", start.elapsed().as_millis(), data);
     Ok(())
 }
 
-#[actix_rt::test]
+#[tokio::test]
 async fn long_query() -> Result<()> {
     let client = Client::new("velvetpractice.live:19132").await?;
     let start = Instant::now();
@@ -21,7 +21,7 @@ async fn long_query() -> Result<()> {
     Ok(())
 }
 
-#[actix_rt::test]
+#[tokio::test]
 async fn slice_index() -> Result<()> {
     let mut source: Vec<u8> = vec![0x01, 0x02];
     source.write(&crate::packet::PLAYER_KEY).await?;


### PR DESCRIPTION
This is a preface to a later extension for adding a gamespy 3 short query (BASIC STAT) implementation.
Because as of now raknet_ping is named short_query while it should not be named that!